### PR TITLE
Add 'they can't join our group' sound to mute list

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -181,6 +181,13 @@ local defaults = {
     }
 }
 
+local annoyingSounds = {
+	567490, -- invite sent
+	567451, -- invite accepted
+	539839, 540356, 540778, 540941, 540984, 542585, 542862, 540287, 540579, 541222, 542952, 542659, 539901, 541298, 543146, 543174 -- "they can't join our group"
+}
+
+
 ---@diagnostic disable-next-line: duplicate-set-field
 function AutoLayer:OnInitialize()
     LibStub("AceConfig-3.0"):RegisterOptionsTable("AutoLayer", options)
@@ -243,15 +250,16 @@ function AutoLayer:OnInitialize()
     minimap_icon:Register("AutoLayer", bunnyLDB, self.db.profile.minimap)
 end
 
-
 function AutoLayer:MuteAnnoyingSounds()
-    MuteSoundFile(567451)
-    MuteSoundFile(567490)
+	for _, soundFileId in pairs(annoyingSounds) do
+		MuteSoundFile(soundFileId)
+	end
 end
 
 function AutoLayer:UnmuteAnnoyingSounds()
-    UnmuteSoundFile(567451)
-    UnmuteSoundFile(567490)
+	for _, soundFileId in pairs(annoyingSounds) do
+		UnmuteSoundFile(soundFileId)
+	end
 end
 
 function AutoLayer:DebugPrint(...)


### PR DESCRIPTION
The sound is highly disturbing on highly populated servers so I disabled it.

Perhaps it is best to mute it in case if addon has initiated the invite and not the player. For the sake of simplicity I changed the code so the sound is just disabled while addon is enabled.