### PR TITLE
added functionality for string.gsub in invitation whisper

### DIFF
--- a/layering.lua
+++ b/layering.lua
@@ -16,6 +16,16 @@ local function isPlayerLoggingOut()
     return false
 end
 
+local function formatWhisperMessage(template, currentLayer)
+	if template:find("{layer}") then
+		template = template:gsub("{layer}", currentLayer)
+    end
+    if template:find("%%s") then
+        template = string.format(template, currentLayer)
+    end
+    return template
+end
+
 function AutoLayer:pruneCache()
     for i, cachedPlayer in ipairs(playersInvitedRecently) do
         -- delete players that are over 5 minutes old
@@ -347,12 +357,12 @@ function AutoLayer:ProcessSystemMessages(_, a)
 
             -- Continue with the rest of the function if the player is in the list
 
-            local finalMessage = "[AutoLayer] " .. string.format(self.db.profile.inviteWhisperTemplate, currentLayer)
+            local finalMessage = "[AutoLayer] " .. formatWhisperMessage(self.db.profile.inviteWhisperTemplate, currentLayer)
             CTL:SendChatMessage("NORMAL", characterName, finalMessage, "WHISPER", nil, characterName)
         end
 
         if self.db.profile.inviteWhisperReminder then
-            local finalMessage2 = "[AutoLayer] " .. string.format(self.db.profile.inviteWhisperTemplateReminder)
+            local finalMessage2 = "[AutoLayer] " .. formatWhisperMessage(self.db.profile.inviteWhisperTemplateReminder, currentLayer)
             CTL:SendChatMessage("NORMAL", characterName, finalMessage2, "WHISPER", nil, characterName)
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -6,6 +6,24 @@ AutoLayer = LibStub("AceAddon-3.0"):NewAddon("AutoLayer", "AceConsole-3.0", "Ace
 AceGUI = LibStub("AceGUI-3.0")
 local minimap_icon = LibStub("LibDBIcon-1.0")
 
+
+--- A helper function to ensure the length of a whisper won't exceed
+--- the 255 character limit but after currentLayer value substitution.
+--- Assumes layer can be a 2 digit value & assumes "[Autolayer] " preceeds the 
+--- template value in an outgoing whisper message leaving 243 characters to customize.
+local function checkTemplateLength(template)
+    if template:find("{layer}") then
+        template = template:gsub("{layer}", "99")
+    end
+    if template:find("%%s") then
+        template = string.format(template, "99")
+    end
+    if #template > 243 then 
+        return "Value is too long. Maximum length is 243 characters."
+    end
+    return true
+end
+
 local options = {
     name = "AutoLayer",
     handler = AutoLayer,
@@ -111,13 +129,16 @@ local options = {
                     type = 'input',
 					width = 'double',
                     name = 'Whisper Template',
-                    desc = 'Template for invite whispers. Use %s for layer number.',
+                    desc = 'Template for invite whispers. Use {layer} for layer number.',
                     set = function(info, val)
                         AutoLayer.db.profile.inviteWhisperTemplate = val
                     end,
                     get = function(info)
                         return AutoLayer.db.profile.inviteWhisperTemplate
                     end,
+					validate = function(info, val)
+						return checkTemplateLength(val)
+					end,
                     order = 5,
 				},
                 inviteWhisperReminder = {
@@ -143,6 +164,9 @@ local options = {
                     get = function(info)
                         return AutoLayer.db.profile.inviteWhisperTemplateReminder
                     end,
+					validate = function(info, val)
+						return checkTemplateLength(val)
+					end,
                     order = 7,
                 },
             },
@@ -208,7 +232,7 @@ local defaults = {
         blacklist = "wts,wtb,lfm,lfg,ashen,auto inv,autoinv,pst for,guild,raid,enchant,player,what layer,which layer, WorldBuffs",
         invertKeywords = "not,off,except,but,out,other than,besides,apart from",
         inviteWhisper = true,
-        inviteWhisperTemplate = "Inviting you to layer %s...",
+        inviteWhisperTemplate = "Inviting you to layer {layer}...",
 		inviteWhisperReminder = true,
 		inviteWhisperTemplateReminder = "Please Leave Party after layer switch",
         mutesounds = true,


### PR DESCRIPTION
I wanted to have an invitation message that advocates for the use of inverse phrases in the /layer channel something akin to this:

> Inviting you to layer **1**. If you are UNHAPPY with this layer, decline my invite and type in /layer channel like "layer not **1**"

*where **1** is my current layer

string.format doesn't natively allow you to use multiple %s values in the string so I created a helper function to also allow the use of string.gsub to look for the characters: {layer}.

This allows you to use the layer number multiple times in a whisper.

The helper also still checks the string for a **%s** and will apply a string.format if found. This maintains current compatibility with today's users' current saved template strings