### PR TITLE
reverted the reminder whisper to reuse string.format

### DIFF
--- a/layering.lua
+++ b/layering.lua
@@ -362,7 +362,7 @@ function AutoLayer:ProcessSystemMessages(_, a)
         end
 
         if self.db.profile.inviteWhisperReminder then
-            local finalMessage2 = "[AutoLayer] " .. formatWhisperMessage(self.db.profile.inviteWhisperTemplateReminder, currentLayer)
+            local finalMessage2 = "[AutoLayer] " .. string.format(self.db.profile.inviteWhisperTemplateReminder)
             CTL:SendChatMessage("NORMAL", characterName, finalMessage2, "WHISPER", nil, characterName)
         end
     end


### PR DESCRIPTION
I hastily added my new function to the reminder whisper which formats the currentlayer into the string but if the current layer is not known it appears to cause problems.

I may create a more robust solution in the future