### PR TITLE
hide whispers & system group messages

### DIFF
--- a/configuration.lua
+++ b/configuration.lua
@@ -77,8 +77,22 @@ function AutoLayer:Toggle()
     self:Print(self.db.profile.enabled and "enabled" or "disabled")
 
     if self.db.profile.enabled then
+        if self.db.profile.hideAutoWhispers then
+            self.filterChatEventAutoLayerWhisperMessages()
+        end
+        if self.db.profile.hideSystemGroupMessages then
+            self:filterChatEventSystemGroupMessages()
+        end
+    
         addonTable.bunnyLDB.icon = [[Interface\AddOns\AutoLayer_Vanilla\Textures\AutoLayer_enabled_icon]]
     else
+        if self.db.profile.hideAutoWhispers then
+            self.unfilterChatEventAutoLayerWhisperMessages()
+        end
+        if self.db.profile.hideSystemGroupMessages then
+            self:unfilterChatEventSystemGroupMessages()
+        end
+
         addonTable.bunnyLDB.icon = [[Interface\AddOns\AutoLayer_Vanilla\Textures\AutoLayer_disabled_icon]]
     end
 end

--- a/main.lua
+++ b/main.lua
@@ -219,6 +219,40 @@ local options = {
                     end,
                     order = 3,
                 },
+                hideAutoWhispers = {
+                    type = 'toggle',
+                    name = 'Hide AddOn Whispers',
+                    desc = 'Silence auto whispers sent out by AutoLayer',
+                    set = function(info, val)
+                        AutoLayer.db.profile.hideAutoWhispers = val
+                        if val then
+                            AutoLayer:filterChatEventAutoLayerWhisperMessages()
+                        else
+                            AutoLayer:unfilterChatEventAutoLayerWhisperMessages()
+                        end
+                    end,
+                    get = function(info)
+                        return AutoLayer.db.profile.hideAutoWhispers
+                    end,
+                    order = 4,
+                },
+                hideSystemGroupMessages = {
+                    type = 'toggle',
+                    name = 'Hide Group Notices',
+                    desc = 'Silence system group notices eg. "X has left the party"',
+                    set = function(info, val)
+                        AutoLayer.db.profile.hideSystemGroupMessages = val
+                        if val then
+                            AutoLayer:filterChatEventSystemGroupMessages()
+                        else
+                            AutoLayer:unfilterChatEventSystemGroupMessages()
+                        end
+                    end,
+                    get = function(info)
+                        return AutoLayer.db.profile.hideSystemGroupMessages
+                    end,
+                    order = 5,
+                },
             },
         },
     },
@@ -237,6 +271,8 @@ local defaults = {
 		inviteWhisperTemplateReminder = "Please Leave Party after layer switch",
         mutesounds = true,
         guildOnly = false,
+        hideAutoWhispers = true,
+        hideSystemGroupMessages = true,
         layered = 0,
         minimap = {
             hide = false,
@@ -251,6 +287,27 @@ local annoyingSounds = {
 	567451, -- invite accepted
 	539839, 540356, 540778, 540941, 540984, 542585, 542862, 540287, 540579, 541222, 542952, 542659, 539901, 541298, 543146, 543174 -- "they can't join our group"
 }
+
+local systemMessages = {
+    ERR_INVITE_PLAYER_S,
+    ERR_JOINED_GROUP_S,
+    ERR_DECLINE_GROUP_S,
+    ERR_GROUP_DISBANDED,
+    ERR_LEFT_GROUP_S,
+    ERR_LEFT_GROUP_YOU,
+    ERR_DUNGEON_DIFFICULTY_CHANGED_S,
+    ERR_ALREADY_IN_GROUP_S,
+}
+
+local function matchesAnySystemMessage(msg)
+    for _, systemMessage in ipairs(systemMessages) do            
+        local pattern = systemMessage:gsub("%%s", "(.+)")
+        if msg:match(pattern) then
+            return true
+        end            
+    end
+    return false
+end
 
 
 ---@diagnostic disable-next-line: duplicate-set-field
@@ -268,6 +325,14 @@ function AutoLayer:OnInitialize()
 
     if self.db.profile.mutesounds then
         self:MuteAnnoyingSounds()
+    end
+
+    if self.db.profile.hideAutoWhispers then
+        self.filterChatEventAutoLayerWhisperMessages()
+    end
+
+    if self.db.profile.hideSystemGroupMessages then
+        self:filterChatEventSystemGroupMessages()
     end
 
     ---@diagnostic disable-next-line: missing-fields
@@ -325,6 +390,30 @@ function AutoLayer:UnmuteAnnoyingSounds()
 	for _, soundFileId in pairs(annoyingSounds) do
 		UnmuteSoundFile(soundFileId)
 	end
+end
+
+--For hiding outgoing automatic whispers
+local function whisperInformFilter(self, event, msg, author, ...)            
+    local filtered =  string.sub(msg, 1, 11) == "[AutoLayer]"  
+    return filtered, msg, author,...            
+end        
+function AutoLayer:filterChatEventAutoLayerWhisperMessages()
+    ChatFrame_AddMessageEventFilter("CHAT_MSG_WHISPER_INFORM", whisperInformFilter)
+end
+function AutoLayer:unfilterChatEventAutoLayerWhisperMessages()
+	ChatFrame_RemoveMessageEventFilter("CHAT_MSG_WHISPER_INFORM", whisperInformFilter)
+end
+
+--For hiding group system messages
+local function systemFilter(self, event, msg, author, ...)
+    local filtered = AutoLayer:GetEnabled() and matchesAnySystemMessage(msg)
+    return filtered, msg, author,...
+end
+function AutoLayer:filterChatEventSystemGroupMessages()
+    ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", systemFilter) 
+end
+function AutoLayer:unfilterChatEventSystemGroupMessages()
+	ChatFrame_RemoveMessageEventFilter("CHAT_MSG_SYSTEM", systemFilter)
 end
 
 function AutoLayer:DebugPrint(...)


### PR DESCRIPTION
addresses #25 

Works great if player has the game "New Whisper" setting set to "In-Line", otherwise you get empty Whisper Tabs, which I don't know how to fix, but it's not any worse than what's in game with Autolayer's current functionality today.

![2025-02-20 16_10_07-World of Warcraft](https://github.com/user-attachments/assets/17a59291-a31f-44bc-9736-99688f1c11b3)
![2025-02-20 16_09_25-World of Warcraft](https://github.com/user-attachments/assets/1e01623a-42c2-4b01-a233-1a81a36a715c)
![2025-02-20 16_07_13-World of Warcraft](https://github.com/user-attachments/assets/046b37f6-2c64-4254-81e1-577d03bbe11a)
