### PR TITLE
fix: register hopper frame so it closes with esc key

### DIFF
--- a/hopping.lua
+++ b/hopping.lua
@@ -29,6 +29,10 @@ function AutoLayer:HopGUI()
   frame:SetStatusText("Beta feature")
   frame:SetLayout("Flow")
 
+  -- Register the frame so it closes when pressing ESC
+  _G["AutoLayerHopperFrame"] = frame.frame
+  tinsert(UISpecialFrames, "AutoLayerHopperFrame")
+
   -- Set a background color and padding
   frame:SetCallback("OnClose", function()
     is_closed = true


### PR DESCRIPTION
Small fix to register the add-on frame so that it respects the esc key

Currently, if the hopper window is open and you hit the escape key, the frame stays open and the game menu opens below it:

<img width="591" alt="Screenshot 2025-04-14 at 12 50 12" src="https://github.com/user-attachments/assets/8221eef4-44ee-4194-84d2-646ec5eb4210" />

This fix makes sure the frame closes when the esc key is pressed