### PR TITLE
Prevent invites on full group

### DIFF
--- a/layering.lua
+++ b/layering.lua
@@ -351,7 +351,7 @@ function AutoLayer:ProcessMessage(
 	local isSeasonal = C_Seasons.HasActiveSeason()
 
 	---@diagnostic disable-next-line: undefined-global
-	if GetNumGroupMembers() < max_group_size then
+	if GetNumGroupMembers() <= max_group_size then
 		if not isHighPriorityRequest and (not self.db.profile.inviteWhisper or not currentLayer or currentLayer <= 0) then
 			self:DebugPrint(
 				"Auto-whisper is turned off or we can't provide a helpful whisper, delaying our invite by 500 miliseconds"


### PR DESCRIPTION
Observed in TBC Anniversary (client version 2.5.5) with version v1.7.0 of AutoLayer.

When your group is already full, AutoLayer will still try to invite new people when it processes a message.
This will spam a "Your party is full" system message in your chat, as well as play a "I can't" / "I can't do that" sound effect. This is highly distracting/annoying. This issue was also raised as part of #65 

This PR aims to fix this behavior. I have tested this on my local game with debug mode enabled and it seems to work as intended. But this is also my first time tinkering with LUA, so please feel free to give me any constructive feedback how I can improve anything.