### PR TITLE
Added check for leader in party and only run if you are leader

### DIFF
--- a/layering.lua
+++ b/layering.lua
@@ -286,9 +286,21 @@ function AutoLayer:ProcessMessage(
 		"'"
 	)
 
-	if self.db.profile.turnOffWhileRaidAssist and IsInRaid() and UnitIsGroupAssistant("player") then
-		self:DebugPrint("Ignoring request because we are raid assist!")
-		return
+	-- Check if player has permission to invite (leader for party, leader or assist for raid)
+	if (IsInGroup() or IsInRaid()) then
+		local isLeader = UnitIsGroupLeader("player")
+		local isRaidAssist = IsInRaid() and UnitIsGroupAssistant("player")
+		local turnOffForAssist = self.db.profile.turnOffWhileRaidAssist and isRaidAssist
+		
+		if turnOffForAssist then
+			self:DebugPrint("Ignoring request because we are raid assist and turnOffWhileRaidAssist is enabled!")
+			return
+		end
+		
+		if not isLeader and not isRaidAssist then
+			self:DebugPrint("Ignoring request because we are not the group leader or raid assist!")
+			return
+		end
 	end
 
 	local currentLayer = AutoLayer:getCurrentLayer()


### PR DESCRIPTION
Updatex raid logic to also check if you are party leader to avoid the "you are not party leader" spam for non raid groups. Related to Issue #65.

As my LUi is very basic i've not been able to fully test it except for a few ingame tests. Should be verified before someone more experienced before impletemented