### PR TITLE
Filter system messages with special characters

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -353,7 +353,10 @@ local systemMessages = {
 
 local function matchesAnySystemMessage(msg)
 	for _, systemMessage in ipairs(systemMessages) do
-		local pattern = systemMessage:gsub("%%s", "(.+)")
+		-- First escape all Lua pattern special characters
+        local pattern = systemMessage:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
+        -- Now replace the escaped %%s with capture pattern
+        pattern = pattern:gsub("%%%%s", "(.+)")
 		if msg:match(pattern) then
 			return true
 		end


### PR DESCRIPTION
Since TBC Anniversary, the `ERR_DUNGEON_DIFFICULTY_CHANGED_S` system message has changed from just:

> Dungeon Difficulty set to %s.

To:

> Dungeon Difficulty set to %s. (All saved instances have been reset)

The parentheses mess up the pattern matching logic, since LUA interprets the `(All saved instances have been reset)` part as a capture group now.

This PR changes the filtering logic by first escaping any possible special characters, being `^`, `$`, `(`, `)`, `%`, `.`, `[`, `]`, `*`, `+`, `-` and `?` by prefixing the character with `%` (so any future changes or cases I have not yet encountered should be covered too).

As a result, any instances of `%s` would also be escaped to a literal `%%s` and thus the final gsub now looks for `%%%%s`, instead of just `%%s`.

Also attached a screenshot below of the new logic in action with my custom debug prints where you can see the `.`, `(` and `)` all being escaped now when attempting to match the string.

<img width="549" height="114" alt="image" src="https://github.com/user-attachments/assets/827601bb-5464-443d-992b-c108f59a1176" />
