### PR TITLE
Bump version in toc file

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.6.9
+## Version: 1.7.4
 ## SavedVariables: AutoLayerDB
 
 embeds.xml


### PR DESCRIPTION
The version number in the toc file hasn't been updated, causing the in-game version to still show v1.6.9, even when on a newer version.

<img width="362" height="139" alt="image" src="https://github.com/user-attachments/assets/a5ba2876-6aef-4bbb-83d8-e4e758983a19" />

I'm just pre-bumping this to 1.7.4, since 1.7.3 was already released. So this change can be included in the next release (in itself, just this toc file update doesn't warrant a release of its own I would say).