### PR TITLE
Process send queue immediately after requesting layer change

### DIFF
--- a/hopping.lua
+++ b/hopping.lua
@@ -14,6 +14,7 @@ function AutoLayer:SendLayerRequest()
 	LeaveParty()
 	table.insert(addonTable.send_queue, res)
 	AutoLayer:DebugPrint("Sending layer request: " .. res)
+	ProccessQueue()
 end
 
 function AutoLayer:HopGUI()


### PR DESCRIPTION
Attempting to fix #51 by just immediately processing the send queue after a layering request has been added to it.
This way, the player does not have to press a key or click their mouse for the invitation to a new layer to come in.