### PR TITLE
Add slash command to request hop

### DIFF
--- a/hopping.lua
+++ b/hopping.lua
@@ -16,6 +16,42 @@ function AutoLayer:SendLayerRequest()
 	AutoLayer:DebugPrint("Sending layer request: " .. res)
 end
 
+function AutoLayer:SlashCommandRequest(input)
+	if not is_closed then
+		return self:Print("Hopper GUI is already open. Use either the GUI or slash commands, not both.")
+	end
+
+	selected_layers = {}
+	local slash_layers = self:GetArgs(input, 1, 5)
+
+	if slash_layers and slash_layers ~= "" then
+		self:DebugPrint("Received slash command request for layers:", slash_layers)
+
+		for layer in string.gmatch(slash_layers, '(%d+)') do
+			table.insert(selected_layers, layer)
+		end
+
+		if #selected_layers == 0 then
+			self:Print("No valid layers specified in the request. Use a comma-separated list of layer numbers. For example: /autolayer req 1,2,3")
+			return
+		end
+	else
+		self:DebugPrint("Received slash command request for all layers except current ( layer", NWB_CurrentLayer, ").")
+
+		local count = 0
+		for _ in pairs(addonTable.NWB.data.layers) do
+			count = count + 1
+			if count ~= NWB_CurrentLayer then
+				table.insert(selected_layers, tostring(count))
+			end
+		end
+	end
+
+	if #selected_layers > 0 then
+		AutoLayer:SendLayerRequest()
+	end
+end
+
 function AutoLayer:HopGUI()
 	if not is_closed then
 		return

--- a/main.lua
+++ b/main.lua
@@ -398,9 +398,13 @@ function AutoLayer:OnInitialize()
 	local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 	AceConfigDialog:SetDefaultSize("AutoLayer", 600, 500)
 	
-	-- Register slash commands to open options
-	self:RegisterChatCommand("autolayer", function()
-		AceConfigDialog:Open("AutoLayer")
+	-- Register slash commands
+	self:RegisterChatCommand("autolayer", function(input)
+		if input == "" then
+			AceConfigDialog:Open("AutoLayer")
+		else
+			AutoLayer:SlashCommand(input)
+		end
 	end)
 	self:RegisterChatCommand("al", function()
 		AceConfigDialog:Open("AutoLayer")
@@ -504,6 +508,24 @@ function AutoLayer:filterChatEventSystemGroupMessages()
 end
 function AutoLayer:unfilterChatEventSystemGroupMessages()
 	ChatFrame_RemoveMessageEventFilter("CHAT_MSG_SYSTEM", systemFilter)
+end
+
+function AutoLayer:SlashCommand(input)
+	local command = self:GetArgs(input, 1)
+
+	if command == "help" then
+		return AutoLayer:SlashCommandHelp()
+	elseif command == "req" then
+		return AutoLayer:SlashCommandRequest(input)
+	else
+		return self:Print("Unknown command " .. command .. ". Type /autolayer help for a list of commands.")
+	end
+end
+
+function AutoLayer:SlashCommandHelp()
+	self:Print("AutoLayer Slash Commands:")
+	self:Print("/autolayer or /al - Open the AutoLayer settings GUI.")
+	self:Print("/autolayer req [layers] - Send a layer hop request via chat. '[layers]' is a comma-separated list of layer numbers to request. If omitted, requests all layers except the current one.")
 end
 
 function AutoLayer:DebugPrint(...)


### PR DESCRIPTION
Adds a `/autolayer req` slash command to allow players to request a hop conveniently from their chat input without necessarily having to have the layer channel open (or know which number it's under) or write into another chat.

- `/autolayer req` requests all layers except the current
- `/autolayer req 1,2,3` requests a hop to layers 1, 2 or 3
- `/autolayer` or `/al` remains to have the same functionality and opens the settings window
- `/autolayer help` was introduced to show all possible slash commands

Closes #61 