### PR TITLE
Fix auto-kick action

### DIFF
--- a/layering.lua
+++ b/layering.lua
@@ -602,7 +602,7 @@ function AutoLayer:HandleAutoKick()
 		end
 
 		self:DebugPrint("Kicking ", name)
-		C_PartyInfo.UninviteUnit(name)
+		UninviteUnit(name)
 	end
 end
 


### PR DESCRIPTION
While testing the difference between having this option on and off for #90 , I noticed it was throwing the error:

> attempt to call field 'UninviteUnit' (a nil value)

It appears that this action is not part of the C_PartyInfo group (anymore), but [just a global command](https://wowpedia.fandom.com/wiki/API_UninviteUnit).

This changes fixes the error from appearing.