### PR TITLE
Strict trigger matching

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.7.7
+## Version: 1.7.8
 ## SavedVariables: AutoLayerDB
 
 embeds.xml

--- a/configuration.lua
+++ b/configuration.lua
@@ -34,7 +34,7 @@ end
 function AutoLayer:ParseTriggers()
 	local triggers = {}
 	for trigger in string.gmatch(self.db.profile.triggers, "[^,]+") do
-		table.insert(triggers, string.lower("*" .. trigger .. "*"))
+		table.insert(triggers, string.lower(trigger))
 	end
 	return triggers
 end

--- a/layering.lua
+++ b/layering.lua
@@ -179,9 +179,9 @@ local function containsAnyTriggersFromList(msg, listOfTriggers)
 	local lowermsg = string.lower(msg)
 
 	for _, trigger in ipairs(listOfTriggers) do
-		local pattern = string.gsub(trigger, "%*", ".*")
-
-		if string.match(lowermsg, "^" .. pattern .. "$") then
+		-- Match trigger as a whole word, case-insensitive
+		-- %f[%w] matches word boundary (lowercase w is start of word, uppercase W is end of word)
+		if string.match(lowermsg, "%f[%w]" .. string.lower(trigger) .. "%f[%W]") then
 			return trigger -- Return the trigger that matched
 		end
 	end


### PR DESCRIPTION
Currently, the triggers are "loosely matched", meaning that if "layer" is in the middle of a word (like player or slayer), it will still count as a match. This change makes it so that the trigger has to be a word on it's own. Tested this and it still reacts to messages like:

- layer
- inv layer
- inv layer 1,2,3
- layer 1,2,3

Fixes #109 