### PR TITLE
Add layer segment support (for split Azeroth/Outland layers)

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.7.9
+## Version: 1.8.0
 ## SavedVariables: AutoLayerDB
 
 embeds.xml

--- a/hopping.lua
+++ b/hopping.lua
@@ -10,7 +10,14 @@ local is_closed = true
 local send
 
 function AutoLayer:SendLayerRequest()
-	local res = "inv layer "
+	local res = ""
+
+	if self.db.profile.layerSegments and addonTable.currentLayerSegment then
+		self:DebugPrint("Using layer segment:", addonTable.currentLayerSegment)
+		res = "<" .. addonTable.currentLayerSegment .. "> "
+	end
+
+	res = res .. "inv layer "
 	res = res .. table.concat(selected_layers, ",")
 	LeaveParty()
 	table.insert(addonTable.send_queue, res)

--- a/main.lua
+++ b/main.lua
@@ -586,6 +586,10 @@ function AutoLayer:OnInitialize()
 					tooltip:AddLine("Current layer: " .. currentLayer)
 				end
 			end
+
+			if addonTable.currentLayerSegment then
+				tooltip:AddLine("Layer segment: " .. addonTable.layerSegments[addonTable.currentLayerSegment])
+			end
 		end,
 	})
 

--- a/main.lua
+++ b/main.lua
@@ -214,6 +214,19 @@ local options = {
                     width = 1,
                     order = 10,
                 },
+				layerSegments = {
+					type = "toggle",
+					name = "Use Layer Segments",
+					desc = "Only invite players in the same layer segment. (e.g. Azeroth, Outland). This avoids party members not layering due to being in a different area of the world that uses different layers.",
+					set = function(info, val)
+						AutoLayer.db.profile.layerSegments = val
+					end,
+					get = function(info)
+						return AutoLayer.db.profile.layerSegments
+					end,
+					width = "full",
+					order = 11,
+				},
 			},
 		},
 
@@ -384,6 +397,7 @@ local defaults = {
 		},
 		autokick = false,
 		turnOffWhileRaidAssist = true,
+		layerSegments = true,
 	},
 }
 
@@ -449,6 +463,35 @@ local systemMessages = {
 	ERR_SET_LOOT_THRESHOLD_S,
 }
 
+-- Layers are sometimes segmented by different areas, this table determines the segments to look for (values should be a name that can be returned by C_Map.GetMapInfo()).
+addonTable.layerSegments = {
+	"Azeroth",
+	"Outland",
+}
+
+-- Determine in which layer segment the player is.
+-- This is necessary for the addon to work correctly in different segments (e.g. Azeroth vs Outland), as layers are specific to them.
+function AutoLayer:GetLayerSegment()
+	local mapID = C_Map.GetBestMapForUnit("player")
+	if not mapID then return nil end
+
+	local mapInfo = C_Map.GetMapInfo(mapID)
+	if not mapInfo then return nil end
+
+	while mapInfo.parentMapID and mapInfo.parentMapID ~= 0 do
+		if tContains(addonTable.layerSegments, mapInfo.name) then
+			self:DebugPrint("Player is in segment:", mapInfo.name)
+			return mapInfo.name
+		end
+
+		mapInfo = C_Map.GetMapInfo(mapInfo.parentMapID)
+	end
+
+	-- If there was no match, return nil
+	self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit("player"), "map name", C_Map.GetMapInfo(mapID).name)
+	return nil
+end
+
 local function matchesAnySystemMessage(msg)
 	for _, systemMessage in ipairs(systemMessages) do
 		-- First escape all Lua pattern special characters
@@ -500,6 +543,10 @@ function AutoLayer:OnInitialize()
 
 	if self.db.profile.hideSystemGroupMessages then
 		self:filterChatEventSystemGroupMessages()
+	end
+
+	if self.db.profile.layerSegments then
+		addonTable.currentLayerSegment = self:GetLayerSegment()
 	end
 
 	---@diagnostic disable-next-line: missing-fields

--- a/main.lua
+++ b/main.lua
@@ -465,8 +465,8 @@ local systemMessages = {
 
 -- Layers are sometimes segmented by different areas, this table determines the segments to look for (values should be a name that can be returned by C_Map.GetMapInfo()).
 addonTable.layerSegments = {
-	"Azeroth",
-	"Outland",
+	["AZ"] = "Azeroth",
+	["OL"] = "Outland",
 }
 
 -- Determine in which layer segment the player is.
@@ -479,9 +479,11 @@ function AutoLayer:GetLayerSegment()
 	if not mapInfo then return nil end
 
 	while mapInfo.parentMapID and mapInfo.parentMapID ~= 0 do
-		if tContains(addonTable.layerSegments, mapInfo.name) then
-			self:DebugPrint("Player is in segment:", mapInfo.name)
-			return mapInfo.name
+		for k, v in pairs(addonTable.layerSegments) do
+			if mapInfo.name == v then
+				self:DebugPrint("Player is in segment:", mapInfo.name)
+				return k
+			end
 		end
 
 		mapInfo = C_Map.GetMapInfo(mapInfo.parentMapID)


### PR DESCRIPTION
Since the PR that targeted #104 has been closed, I'm not sure if this was still being worked on, while it is an annoying bug.
So this is my attempt to fix it.

I wanted to keep it simple and backwards compatible with older versions of the client.
It introduces what I call a "layer segment prefix". Currently, the supported layer segments are "Azeroth" and "Outland", but this can be extended in future versions where necessary.

The feature can be turned off in the options panel, but due to the severeness of this issue (it prevents layering from happening as intended), I have enabled it by default for everyone. When turned on, it works as follows:

- Upon logging in or when changing areas in the game, the player's current layer segment is determined based on their location on the map. We do this by traversing over each `parentMapID` value of `C_Map.GetMapInfo()` until a hit is found. If no hits are found, the segment is set to `nil` and the addon will continue to function as it does today.

- Whenever a player sends a layer request, it will now be prefixed by the layer segment, for example `<Azeroth>` or `<Outland>`. Older clients will simply ignore/discard this as garbage and continue to invite as usual:

<img width="520" height="97" alt="image" src="https://github.com/user-attachments/assets/53a92c33-b30d-42d5-9487-7712fe94da57" />

- Up-to-date clients will recognize the segment prefix and match it against the inviting player's current layer segment. If they do not match, the request is ignored.

This is going to take some time to roll out properly, since all clients will need to run this version or later to avoid "wrong" invites, but I also don't see any way to avoid that.