### PR TITLE
Register options panel with Blizzard UI

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -465,6 +465,7 @@ end
 ---@diagnostic disable-next-line: duplicate-set-field
 function AutoLayer:OnInitialize()
 	LibStub("AceConfig-3.0"):RegisterOptionsTable("AutoLayer", options)
+	LibStub("AceConfigDialog-3.0"):AddToBlizOptions("AutoLayer")
 	self.db = LibStub("AceDB-3.0"):New("AutoLayerDB", defaults)
 	
 	-- Modern API for adding options


### PR DESCRIPTION
Register the options panel with the Blizzard Options UI, so AutoLayer can be found under Options > AddOns.

<img width="1162" height="922" alt="image" src="https://github.com/user-attachments/assets/ace20321-be15-4f47-b2e4-940ef2ffb860" />

Not every user might be aware of the slash commands, so this gives them another way to get there, plus it centralizes all of their addon configs, since most others are there as well.

This is probably not big/interesting enough to be a release on itself, but it could be included with the next one when it's due.