### PR TITLE
Cooldown note

### DIFF
--- a/hopping.lua
+++ b/hopping.lua
@@ -222,4 +222,10 @@ function AutoLayer:HopGUI()
 		send:SetText("Request Any Layer")
 	end
 	frame:AddChild(send)
+
+	-- Add a label explaining there is a cooldown on layering
+	local cooldownLabel = AceGUI:Create("Label")
+	cooldownLabel:SetText("|cffff0000Note:|r Blizzard enforces an increasing cooldown on layering.\nThe more you attempt to layer, the longer it takes each time.|r")
+	cooldownLabel:SetFullWidth(true)
+	frame:AddChild(cooldownLabel)
 end


### PR DESCRIPTION
Add a note to the hopper GUI about the [increasing cooldown](https://us.forums.blizzard.com/en/wow/t/new-increasing-cooldown-for-changing-layers/290703) that is enforced.

<img width="511" height="342" alt="image" src="https://github.com/user-attachments/assets/e1655c9d-e9fc-4b52-ac04-4149171848f3" />

I feel like not everyone is very aware of this (sometimes I will get party messages or whispers like "why am I not layering?") and when you explain it, they had no idea. So I think it'd be a good note to include for awareness.

Just like #115, not really worth a release by itself, but it can be included in a bigger update.