### PR TITLE
Fix arena layer segment error

### DIFF
--- a/layering.lua
+++ b/layering.lua
@@ -685,7 +685,10 @@ function AutoLayer:ProcessZoneChange()
 			self:DebugPrint("Current layer segment set to:", layer_segment)
 		else
 			addonTable.currentLayerSegment = nil
-			self:Print("|cffff0000ERROR:|r Could not determine layer segment for current zone. This is a bug, please consider reporting it at https://github.com/iraizo/AutoLayer/issues ! Include details about which zone you are in.")
+			-- Arenas do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, this is probably a new zone that was not yet added.
+			if not IsActiveBattlefieldArena() then
+				self:Print("|cffff0000ERROR:|r Could not determine layer segment for current zone. This is a bug, please consider reporting it at https://github.com/iraizo/AutoLayer/issues ! Include details about which zone you are in.")
+			end
 		end
 	end
 end

--- a/main.lua
+++ b/main.lua
@@ -490,7 +490,11 @@ function AutoLayer:GetLayerSegment()
 	end
 
 	-- If there was no match, return nil
-	self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit("player"), "map name", C_Map.GetMapInfo(mapID).name)
+	if not IsActiveBattlefieldArena() then
+		-- Arenas do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, we should write a debug message.
+		self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit("player"), "map name", C_Map.GetMapInfo(mapID).name)
+	end
+
 	return nil
 end
 


### PR DESCRIPTION
Fixes #118 

When the player changes zones into an arena, it is expected that there is no mapID and thus the layer segment cannot be determined. The addon should not throw the "unknown zone" error in this case.