### PR TITLE
Fix localization issue and PVP Barracks

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.8.0
+## Version: 1.8.2
 ## SavedVariables: AutoLayerDB
 
 embeds.xml

--- a/layering.lua
+++ b/layering.lua
@@ -685,8 +685,8 @@ function AutoLayer:ProcessZoneChange()
 			self:DebugPrint("Current layer segment set to:", layer_segment)
 		else
 			addonTable.currentLayerSegment = nil
-			-- Arenas do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, this is probably a new zone that was not yet added.
-			if not IsActiveBattlefieldArena() then
+			-- Arenas and some instances do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, this is probably a new zone that was not yet added.
+			if not IsActiveBattlefieldArena() and not self:IsInMaplessInstance() then
 				self:Print("|cffff0000ERROR:|r Could not determine layer segment for current zone. This is a bug, please consider reporting it at https://github.com/iraizo/AutoLayer/issues ! Include details about which zone you are in.")
 			end
 		end

--- a/main.lua
+++ b/main.lua
@@ -469,6 +469,12 @@ addonTable.layerSegments = {
 	["OL"] = "Outland",
 }
 
+-- Zone names can be localized in the game client, so sometimes we need to match against their mapID instead of name
+addonTable.layerSegmentMapIDs = {
+	["AZ"] = 947,
+	["OL"] = 1945,
+}
+
 -- Determine in which layer segment the player is.
 -- This is necessary for the addon to work correctly in different segments (e.g. Azeroth vs Outland), as layers are specific to them.
 function AutoLayer:GetLayerSegment()
@@ -479,9 +485,9 @@ function AutoLayer:GetLayerSegment()
 	if not mapInfo then return nil end
 
 	while mapInfo.parentMapID and mapInfo.parentMapID ~= 0 do
-		for k, v in pairs(addonTable.layerSegments) do
-			if mapInfo.name == v then
-				self:DebugPrint("Player is in segment:", mapInfo.name)
+		for k, v in pairs(addonTable.layerSegmentMapIDs) do
+			if mapInfo.mapID == v then
+				self:DebugPrint("Player is in segment:", addonTable.layerSegments[k])
 				return k
 			end
 		end
@@ -490,12 +496,33 @@ function AutoLayer:GetLayerSegment()
 	end
 
 	-- If there was no match, return nil
-	if not IsActiveBattlefieldArena() then
-		-- Arenas do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, we should write a debug message.
+	if not IsActiveBattlefieldArena() and not self:IsInMaplessInstance() then
+		-- Arenas and some instances do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, we should write a debug message.
 		self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit("player"), "map name", C_Map.GetMapInfo(mapID).name)
 	end
 
 	return nil
+end
+
+function AutoLayer:IsInMaplessInstance()
+	-- Determine if the player is in a "mapless" instance, which is an instance that does not return a mapID
+	local maplessInstances = {
+		369, -- Deeprun Tram
+		449, -- Champions' Hall in Stormwind (Alliance PVP Barracks)
+		450, -- Hall of Legends in Orgrimmar (Horde PVP Barracks)
+	}
+
+	local _, _, _, _, _, _, _, instanceID = GetInstanceInfo()
+	self:DebugPrint("Current instance ID:", instanceID)
+
+	for _, id in ipairs(maplessInstances) do
+		if instanceID == id then
+			self:DebugPrint("Player is in a mapless instance with ID:", instanceID)
+			return true
+		end
+	end
+
+	return false
 end
 
 local function matchesAnySystemMessage(msg)


### PR DESCRIPTION
Fixes #121

- If the game client is not in English, the layer segments do not work if the game returns a name other than "Azeroth" or "Outland". This triggers the "unknown zone" error. This is now fixed by looking at their respective mapID instead (which is always the same no matter the locale).
- PVP Barracks instances like the Champions' Hall and Hall of Legends currently trigger the "unknown zone" error. These instances do indeed not have a mapID, but this is expected. The error is now suppressed when entering a PVP Barracks (as well as the Deeprun Tram which seemed to have the same issue).
