### PR TITLE
Add layer segment mismatch warning

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.8.2
+## Version: 1.8.3
 ## SavedVariables: AutoLayerDB
 
 embeds.xml

--- a/layering.lua
+++ b/layering.lua
@@ -693,12 +693,28 @@ function AutoLayer:ProcessZoneChange()
 	end
 end
 
+function AutoLayer:ProcessGroupJoined()
+	if self.db.profile.layerSegments and not UnitIsGroupLeader("player") then
+		self:DebugPrint("Group joined, comparing layer segments with leader...")
+		-- Grant the game a little bit of time to process the group join and update any relevant information before we compare segments
+		C_Timer.After(2, function()
+			local playerSegment, leaderSegment = AutoLayer:CompareLayerSegments()
+			if playerSegment ~= leaderSegment then
+				self:Print("|cffffff00WARNING:|r You are in " .. (addonTable.layerSegments[playerSegment] or "an unknown segment") ..
+							", while the party leader is in " .. (addonTable.layerSegments[leaderSegment] or "an unknown segment") ..
+							". You will most likely not layer correctly. You can leave the party and try to layer again.")
+			end
+		end)
+	end
+end
+
 AutoLayer:RegisterEvent("CHAT_MSG_CHANNEL", "ProcessMessage")
 AutoLayer:RegisterEvent("CHAT_MSG_WHISPER", "ProcessMessage")
 AutoLayer:RegisterEvent("CHAT_MSG_GUILD", "ProcessMessage")
 AutoLayer:RegisterEvent("CHAT_MSG_SYSTEM", "ProcessSystemMessages")
 AutoLayer:RegisterEvent("GROUP_ROSTER_UPDATE", "ProcessRosterUpdate")
 AutoLayer:RegisterEvent("ZONE_CHANGED_NEW_AREA", "ProcessZoneChange")
+AutoLayer:RegisterEvent("GROUP_JOINED", "ProcessGroupJoined")
 
 function JoinLayerChannel()
 	-- Join ALL channels to prevent griefing (so griefers can't become admin in empty channels)

--- a/main.lua
+++ b/main.lua
@@ -498,7 +498,7 @@ function AutoLayer:GetLayerSegment(unitID)
 	end
 
 	-- If there was no match, return nil
-	if not IsActiveBattlefieldArena() and not self:IsInMaplessInstance() then
+	if unitID == "player" and not IsActiveBattlefieldArena() and not self:IsInMaplessInstance() then
 		-- Arenas and some instances do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, we should write a debug message.
 		self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit(unitID), "map name", C_Map.GetMapInfo(mapID).name)
 	end

--- a/main.lua
+++ b/main.lua
@@ -475,10 +475,12 @@ addonTable.layerSegmentMapIDs = {
 	["OL"] = 1945,
 }
 
--- Determine in which layer segment the player is.
+-- Determine in which layer segment the given unitID is. Defaults to the player if no unitID is given.
 -- This is necessary for the addon to work correctly in different segments (e.g. Azeroth vs Outland), as layers are specific to them.
-function AutoLayer:GetLayerSegment()
-	local mapID = C_Map.GetBestMapForUnit("player")
+function AutoLayer:GetLayerSegment(unitID)
+	unitID = unitID or "player"
+	self:DebugPrint("Determining layer segment for", unitID .. " (" .. UnitName(unitID) .. ")")
+	local mapID = C_Map.GetBestMapForUnit(unitID)
 	if not mapID then return nil end
 
 	local mapInfo = C_Map.GetMapInfo(mapID)
@@ -487,7 +489,7 @@ function AutoLayer:GetLayerSegment()
 	while mapInfo.parentMapID and mapInfo.parentMapID ~= 0 do
 		for k, v in pairs(addonTable.layerSegmentMapIDs) do
 			if mapInfo.mapID == v then
-				self:DebugPrint("Player is in segment:", addonTable.layerSegments[k])
+				self:DebugPrint(UnitName(unitID), "is in segment:", addonTable.layerSegments[k])
 				return k
 			end
 		end
@@ -498,11 +500,52 @@ function AutoLayer:GetLayerSegment()
 	-- If there was no match, return nil
 	if not IsActiveBattlefieldArena() and not self:IsInMaplessInstance() then
 		-- Arenas and some instances do not have a mapID, so we won't be able to determine a layer segment for them. In any other case, we should write a debug message.
-		self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit("player"), "map name", C_Map.GetMapInfo(mapID).name)
+		self:DebugPrint("Layer segment could not be determined for mapID", C_Map.GetBestMapForUnit(unitID), "map name", C_Map.GetMapInfo(mapID).name)
 	end
 
 	return nil
 end
+
+-- Determine if the party leader is in the same layer segment as the player, if layer segments are enabled.
+function AutoLayer:CompareLayerSegments()
+	if not self.db.profile.layerSegments then
+		return nil, nil -- Layer segments not enabled, so we don't care about the party leader's segment
+	end
+
+	local numGroupMembers = GetNumGroupMembers()
+	if numGroupMembers == 0 then
+		self:DebugPrint("Player is not in a party, so no party leader segment to compare to")
+		return nil, nil
+	end
+
+	-- Iterate through the players in our party until we find the party leader
+	local partyLeaderUnit = nil
+	for i = 1, numGroupMembers do
+		local unitID = "party" .. i
+		if UnitIsGroupLeader(unitID) then
+			partyLeaderUnit = unitID
+			self:DebugPrint("Found party leader unitID:", partyLeaderUnit)
+			break
+		end
+	end
+
+	if not partyLeaderUnit then
+		self:DebugPrint("Could not find party leader unitID")
+		return nil, nil
+	end
+
+	local playerSegment = addonTable.currentLayerSegment or self:GetLayerSegment("player")
+	local leaderSegment = self:GetLayerSegment(partyLeaderUnit)
+
+	if not playerSegment or not leaderSegment then
+		self:DebugPrint("Could not determine layer segment for player or party leader, cannot compare segments")
+		return nil, nil
+	end
+
+	self:DebugPrint("Player segment:", playerSegment, "Leader segment:", leaderSegment)
+
+	return playerSegment, leaderSegment
+end 
 
 function AutoLayer:IsInMaplessInstance()
 	-- Determine if the player is in a "mapless" instance, which is an instance that does not return a mapID


### PR DESCRIPTION
Based on #123 it appears that it's still not always clear when a layer segment mismatch happens and is not causing layering to happen correctly.

To clarify this a bit more I added a warning mechanism if the player attempts to layer and joins a party.
Shortly after joining a party AutoLayer will check if your layer segment and the layer segment for the party leader are the same and emit a warning if that is not the case:

<img width="545" height="129" alt="image" src="https://github.com/user-attachments/assets/0c5e8920-07d8-4c02-aca3-a5cce5de13e8" />

Unfortunately I don't know of any way to determine a player's location prior to joining their party, so warning a user after joining an incompatible party should be the next best thing.

The whole mechanism in action with debug messages:

<img width="553" height="152" alt="image" src="https://github.com/user-attachments/assets/5532d378-32da-41fa-b872-86f5179124c7" />