### PR TITLE
Add Auto-Convert to Raid experimental feature

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.8.3
+## Version: 1.8.4
 ## SavedVariables: AutoLayerDB
 
 embeds.xml

--- a/layering.lua
+++ b/layering.lua
@@ -533,6 +533,22 @@ function AutoLayer:ProcessMessage(
 	end
 end
 
+function AutoLayer:OverrideLootSettings()
+	if self.db.profile.overrideLootSettings and UnitIsGroupLeader("player") then
+		local lootMethod, _, _ = C_PartyInfo.GetLootMethod()
+
+		if lootMethod ~= self.db.profile.lootMethod then
+			self:DebugPrint("Setting loot method to", self.db.profile.lootMethod)
+			C_PartyInfo.SetLootMethod(self.db.profile.lootMethod)
+		end
+
+		if self.db.profile.lootMethod == 3 and GetLootThreshold() ~= self.db.profile.lootThreshold then
+			self:DebugPrint("Setting loot threshold to", self.db.profile.lootThreshold)
+			SetLootThreshold(self.db.profile.lootThreshold)
+		end
+	end
+end
+
 ---@diagnostic disable-next-line: inject-field
 function AutoLayer:ProcessSystemMessages(_, SystemMessages)
 	if not self.db.profile.enabled then
@@ -561,20 +577,9 @@ function AutoLayer:ProcessSystemMessages(_, SystemMessages)
 				break -- Found the player, no need to continue checking
 			end
 		end
+
 		-- Ensure group loot is set as desired
-		if self.db.profile.overrideLootSettings and UnitIsGroupLeader("player") then
-			local lootMethod, _, _ = C_PartyInfo.GetLootMethod()
-
-			if lootMethod ~= self.db.profile.lootMethod then
-				self:DebugPrint("Setting loot method to", self.db.profile.lootMethod)
-				C_PartyInfo.SetLootMethod(self.db.profile.lootMethod)
-			end
-
-			if self.db.profile.lootMethod == 3 and GetLootThreshold() ~= self.db.profile.lootThreshold then
-				self:DebugPrint("Setting loot threshold to", self.db.profile.lootThreshold)
-				SetLootThreshold(self.db.profile.lootThreshold)
-			end
-		end
+		self:OverrideLootSettings()
 	end
 
 	characterName = SystemMessages:match("^" .. ERR_DECLINE_GROUP_S:format("(.+)"))
@@ -674,6 +679,20 @@ end
 
 function AutoLayer:ProcessRosterUpdate()
 	self:getCurrentLayer()
+
+	-- Check if the party needs to be converted to a raid (or vice versa) if the player has the Auto-Convert to Raid option enabled.
+	if self.db.profile.autoConvertRaid then
+		if IsInGroup() and not IsInRaid() and UnitIsGroupLeader("player") and (GetNumGroupMembers() + #pendingPlayerInvites) >= 5 then
+			self:DebugPrint("Converting to raid because we are in a party with 5 or more members and we are the leader")
+			ConvertToRaid()
+		end
+
+		if IsInGroup() and IsInRaid() and UnitIsGroupLeader("player") and (GetNumGroupMembers() + #pendingPlayerInvites) < 5 then
+			self:DebugPrint("Converting to party because we are in a raid with 5 or fewer members and we are the leader")
+			ConvertToParty()
+			self:OverrideLootSettings()
+		end
+	end
 end
 
 function AutoLayer:ProcessZoneChange()

--- a/layering.lua
+++ b/layering.lua
@@ -685,6 +685,7 @@ function AutoLayer:ProcessRosterUpdate()
 		if IsInGroup() and not IsInRaid() and UnitIsGroupLeader("player") and (GetNumGroupMembers() + #pendingPlayerInvites) >= 5 then
 			self:DebugPrint("Converting to raid because we are in a party with 5 or more members and we are the leader")
 			ConvertToRaid()
+			self:OverrideLootSettings()
 		end
 
 		if IsInGroup() and IsInRaid() and UnitIsGroupLeader("player") and (GetNumGroupMembers() + #pendingPlayerInvites) < 5 then

--- a/main.lua
+++ b/main.lua
@@ -268,13 +268,15 @@ local options = {
 				autokick = {
 					type = "toggle",
 					name = "Auto-Kick on Full",
-					desc = "|cffFF0000Requires manual interaction.|r Kicks the last member if the group is full.",
+					desc = "|cffFF0000Requires manual interaction.|r Kicks the last member if the group is full. Mutually exclusive with Auto-Convert to Raid.",
 					set = function(info, val)
 						AutoLayer.db.profile.autokick = val
+						if val then AutoLayer.db.profile.autoConvertRaid = false end
 					end,
 					get = function(info)
 						return AutoLayer.db.profile.autokick
 					end,
+					disabled = function() return AutoLayer.db.profile.autoConvertRaid end,
 					order = 3,
 				},
 				hideAutoWhispers = {
@@ -364,9 +366,37 @@ local options = {
 					get = function(info)
 						return AutoLayer.db.profile.lootThreshold
 					end,
+					hidden = function() return AutoLayer.db.profile.lootMethod ~= 3 end,
 					order = 3,
 				},
 			},
+		},
+		experimental = {
+			type = "group",
+			name = "Experimental Features",
+			inline = true,
+			order = 4,
+			args = {
+				description = {
+					type = "description",
+					name = "These options are |cffff0000experimental|r and have not been widely tested. Please report any issues or feedback at |cff66beffgithub.com/iraizo/AutoLayer/issues|r",
+					order = 1,
+				},
+				autoConvertRaid = {
+					type = "toggle",
+					name = "Auto-Convert to Raid",
+					desc = "Automatically convert to a raid group if the party is full. Mutually exclusive with Auto-Kick on Full.",
+					set = function(info, val)
+						AutoLayer.db.profile.autoConvertRaid = val
+						if val then AutoLayer.db.profile.autokick = false end
+					end,
+					get = function(info)
+						return AutoLayer.db.profile.autoConvertRaid
+					end,
+					disabled = function() return AutoLayer.db.profile.autokick end,
+					order = 2,
+				}
+			}
 		}
 	},
 }
@@ -398,6 +428,7 @@ local defaults = {
 		autokick = false,
 		turnOffWhileRaidAssist = true,
 		layerSegments = true,
+		autoConvertRaid = false,
 	},
 }
 


### PR DESCRIPTION
Addressing one of the feature requests from #65 where the player can opt-in to automatically converting their party to a raid if the group is full. To avoid any conflict with the Auto-Kick feature, they are mutually exclusive. Enabling one automatically disables the other and disables the checkbox for it.

I've tested this locally and it seems to work fine as intended, however since I'm not sure if there are certain situations where the behavior of the addon or the game might change, I've flagged this option as "Experimental feature" and put it in a new section fo the config GUI. This way, it's clear to players that this has not been very thoroughly tested and they can make an informed choice to opt-in or not.

<img width="771" height="668" alt="image" src="https://github.com/user-attachments/assets/3a68ec7e-827a-4088-9cc8-192336287d93" />

This PR also adds a small update to the Loot Override Settings where the "threshold" dropdown will now be hidden if the Loot Method is not set to "Group Loot" (as it only applies to that method).