### PR TITLE
Add layer segment overrides

### DIFF
--- a/AutoLayer_Vanilla.toc
+++ b/AutoLayer_Vanilla.toc
@@ -2,7 +2,7 @@
 ## Title: AutoLayer
 ## Notes: Automatically invites people that want to layer switch
 ## Author: raizo
-## Version: 1.8.3
+## Version: 1.8.4
 ## SavedVariables: AutoLayerDB
 
 embeds.xml

--- a/layering.lua
+++ b/layering.lua
@@ -694,7 +694,7 @@ function AutoLayer:ProcessZoneChange()
 end
 
 function AutoLayer:ProcessGroupJoined()
-	if self.db.profile.layerSegments and not UnitIsGroupLeader("player") then
+	if self.db.profile.layerSegments and self.db.profile.showLayerWarning and not UnitIsGroupLeader("player") then
 		self:DebugPrint("Group joined, comparing layer segments with leader...")
 		-- Grant the game a little bit of time to process the group join and update any relevant information before we compare segments
 		C_Timer.After(2, function()

--- a/main.lua
+++ b/main.lua
@@ -214,19 +214,6 @@ local options = {
                     width = 1,
                     order = 10,
                 },
-				layerSegments = {
-					type = "toggle",
-					name = "Use Layer Segments",
-					desc = "Only invite players in the same layer segment. (e.g. Azeroth, Outland). This avoids party members not layering due to being in a different area of the world that uses different layers.",
-					set = function(info, val)
-						AutoLayer.db.profile.layerSegments = val
-					end,
-					get = function(info)
-						return AutoLayer.db.profile.layerSegments
-					end,
-					width = "full",
-					order = 11,
-				},
 			},
 		},
 
@@ -310,6 +297,33 @@ local options = {
 						return AutoLayer.db.profile.hideSystemGroupMessages
 					end,
 					order = 5,
+				},
+				layerSegments = {
+					type = "toggle",
+					name = "Use Layer Segments",
+					desc = "Only invite players in the same layer segment. (e.g. Azeroth, Outland). This avoids party members not layering due to being in a different area of the world that uses different layers.",
+					set = function(info, val)
+						AutoLayer.db.profile.layerSegments = val
+					end,
+					get = function(info)
+						return AutoLayer.db.profile.layerSegments
+					end,
+					order = 6,
+				},
+				showLayerWarning = {
+					type = "toggle",
+					name = "Layer Segment Warning",
+					desc = "Show a warning when joining a party with a different layer segment, while the layer segment feature is enabled.",
+					set = function(info, val)
+						AutoLayer.db.profile.showLayerWarning = val
+					end,
+					get = function(info)
+						return AutoLayer.db.profile.showLayerWarning
+					end,
+					disabled = function()
+						return not AutoLayer.db.profile.layerSegments
+					end,
+					order = 7,
 				},
 			},
 		},
@@ -398,6 +412,7 @@ local defaults = {
 		autokick = false,
 		turnOffWhileRaidAssist = true,
 		layerSegments = true,
+		showLayerWarning = true,
 	},
 }
 
@@ -475,11 +490,23 @@ addonTable.layerSegmentMapIDs = {
 	["OL"] = 1945,
 }
 
+-- Some zones are not in the same layer segment as the rest of their continent (e.g. they are technically in Azeroth, but part of the Outland layer segment).
+-- Since the regular checks won't work for them, we need to override them to ensure players in those zones get invited correctly.
+addonTable.layerSegmentOverrides = {
+	[1941] = "OL", -- Eversong Woods, Eastern Kingdoms
+	[1942] = "OL", -- Ghostlands, Eastern Kingdoms
+	[1943] = "OL", -- Azuremyst Isle, Kalimdor
+	[1947] = "OL", -- The Exodar, Kalimdor
+	[1950] = "OL", -- Bloodmyst Isle, Kalimdor
+	[1954] = "OL", -- Silvermoon City, Eastern Kingdoms
+	[1957] = "OL", -- Isle of Quel'Danas, Eastern Kingdoms
+}
+
 -- Determine in which layer segment the given unitID is. Defaults to the player if no unitID is given.
 -- This is necessary for the addon to work correctly in different segments (e.g. Azeroth vs Outland), as layers are specific to them.
 function AutoLayer:GetLayerSegment(unitID)
 	unitID = unitID or "player"
-	self:DebugPrint("Determining layer segment for", unitID .. " (" .. UnitName(unitID) .. ")")
+	self:DebugPrint("Determining layer segment for", unitID, "(", UnitName(unitID), ")")
 	local mapID = C_Map.GetBestMapForUnit(unitID)
 	if not mapID then return nil end
 
@@ -487,6 +514,14 @@ function AutoLayer:GetLayerSegment(unitID)
 	if not mapInfo then return nil end
 
 	while mapInfo.parentMapID and mapInfo.parentMapID ~= 0 do
+		-- Check if this mapID has a layer segment override, if so return the override value
+		if addonTable.layerSegmentOverrides[mapInfo.mapID] then
+			local overrideSegment = addonTable.layerSegmentOverrides[mapInfo.mapID]
+			self:DebugPrint(UnitName(unitID), "is in segment:", addonTable.layerSegments[overrideSegment], "( override for mapID", mapInfo.mapID, ")")
+			return overrideSegment
+		end
+
+		-- Check if the current mapID matches any of the layer segment mapIDs, if so return the corresponding segment
 		for k, v in pairs(addonTable.layerSegmentMapIDs) do
 			if mapInfo.mapID == v then
 				self:DebugPrint(UnitName(unitID), "is in segment:", addonTable.layerSegments[k])


### PR DESCRIPTION
Following up on the comments in #123 , adding some "overrides" of zones that are physically in Azeroth, but should layer with Outland.

Tested this with a fresh blood elf character in Eversong Woods and it seems to layer as expected there. Not tested any of the other zones as of yet.

This PR also addresses a few other things:

- The layer segments option was moved to the "Sound and Behavior" settings, rather than "Messaging Settings" as this feels more appropriate
- Added a separate checkbox to allow players to disable the "mismatching layer segment" warning (some players may find this annoying and rather check for this manually).
