### PR TITLE
Fix LeaveParty for TBC classic

### DIFF
--- a/hopping.lua
+++ b/hopping.lua
@@ -9,6 +9,8 @@ local selected_layers = {}
 local is_closed = true
 local send
 
+local LeaveParty = C_PartyInfo and C_PartyInfo.LeaveParty or LeaveParty
+
 function AutoLayer:SendLayerRequest()
 	local res = ""
 
@@ -19,7 +21,7 @@ function AutoLayer:SendLayerRequest()
 
 	res = res .. "inv layer "
 	res = res .. table.concat(selected_layers, ",")
-	C_PartyInfo.LeaveParty()
+	LeaveParty()
 	table.insert(addonTable.send_queue, res)
 	AutoLayer:DebugPrint("Sending layer request: " .. res)
 	ProccessQueue()


### PR DESCRIPTION
C_PartyInfo.LeaveParty does not exist on TBC Classic Anniversary. This simply uses a lua check so it works on every client.
You should likely use this method for every single one of these functions that are different across clients.